### PR TITLE
Restore MUI sources and add useMediaQuery alias

### DIFF
--- a/CRT_PROGRESS.md
+++ b/CRT_PROGRESS.md
@@ -4,6 +4,8 @@
 - Created custom Chakra UI wrappers for various Material UI components in `src/custom`.
 - Added icon replacements using `react-icons` under `src/custom/icons`.
 - Configured `vite.config.ts` to alias `@mui/material` imports to Chakra equivalents.
+- Added path and vite aliases for `@mui/material/useMediaQuery` and
+  `@mui/material/styles` to avoid modifying upstream sources.
 - Added a basic vitest test `iconAlias.test.tsx` to verify icon aliases.
 - Introduced `color2k` helpers and removed remaining imports from `@mui/material/styles`.
 

--- a/packages/material-react-table/src/custom/useMediaQuery.ts
+++ b/packages/material-react-table/src/custom/useMediaQuery.ts
@@ -1,0 +1,7 @@
+import { useMediaQuery as chakraUseMediaQuery, type UseMediaQueryOptions } from '@chakra-ui/react';
+
+export type { UseMediaQueryOptions };
+
+export default function useMediaQuery(query: string, options?: UseMediaQueryOptions) {
+  return chakraUseMediaQuery(query, options)[0];
+}

--- a/packages/material-react-table/src/utils/color.utils.ts
+++ b/packages/material-react-table/src/utils/color.utils.ts
@@ -23,14 +23,7 @@ const mix = (color: string, amount: number, mixWith: number) => {
   );
 };
 
-export const lighten = (color: string, amount: number): string => mix(color, amount, 255);
 
-export const darken = (color: string, amount: number): string => mix(color, amount, 0);
-
-export const alpha = (color: string, value: number): string => {
-  const { r, g, b } = hexToRgb(color);
-  return `rgba(${r}, ${g}, ${b}, ${value})`;
-};
 import { useTheme, type Theme } from '@chakra-ui/react';
 
 interface RGBA {
@@ -150,5 +143,9 @@ export const transparentize = (color: string, amount: number): string => {
   return toRgbaString({ r, g, b, a: clamp(a - amount) });
 };
 
+export const alpha = (color: string, value: number): string => {
+  const { r, g, b } = parseColor(color);
+  return toRgbaString({ r, g, b, a: clamp(value) });
+};
+
 export { useTheme, type Theme };
-export { transparentize as alpha };

--- a/packages/material-react-table/src/utils/style.utils.ts
+++ b/packages/material-react-table/src/utils/style.utils.ts
@@ -1,8 +1,7 @@
 import { type CSSProperties } from 'react';
 import { type TableCellProps } from '@mui/material/TableCell';
 import { type TooltipProps } from '@mui/material/Tooltip';
-import { alpha, darken, lighten } from './color.utils';
-import { darken, lighten, transparentize } from './color.utils';
+import { alpha, darken, lighten, transparentize } from './color.utils';
 import { type Theme } from '@mui/material/styles';
 import {
   type MRT_Column,
@@ -35,8 +34,8 @@ export const getMRTTheme = <TData extends MRT_RowData>(
         ? darken(muiTheme.palette.warning.dark, 0.25)
         : lighten(muiTheme.palette.warning.light, 0.5),
     menuBackgroundColor: lighten(baseBackgroundColor, 0.07),
-    pinnedRowBackgroundColor: transparentize(muiTheme.palette.primary.main, 0.9),
-    selectedRowBackgroundColor: transparentize(muiTheme.palette.primary.main, 0.8),
+    pinnedRowBackgroundColor: alpha(muiTheme.palette.primary.main, 0.1),
+    selectedRowBackgroundColor: alpha(muiTheme.palette.primary.main, 0.2),
     ...mrtThemeOverrides,
   };
 };

--- a/packages/material-react-table/tsconfig.json
+++ b/packages/material-react-table/tsconfig.json
@@ -40,6 +40,8 @@
       "@mui/material/TableBody": ["./src/custom/TableBody"],
       "@mui/material/TableFooter": ["./src/custom/TableFooter"],
       "@mui/material/TableContainer": ["./src/custom/TableContainer"],
+      "@mui/material/useMediaQuery": ["./src/custom/useMediaQuery"],
+      "@mui/material/styles": ["./src/utils/color.utils"],
       "@mui/icons-material/*": ["./src/custom/icons/*"]
     }
   },

--- a/packages/material-react-table/vite.config.ts
+++ b/packages/material-react-table/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       '@mui/material/TableBody': resolve(__dirname, 'src/custom/TableBody.tsx'),
       '@mui/material/TableFooter': resolve(__dirname, 'src/custom/TableFooter.tsx'),
       '@mui/material/TableContainer': resolve(__dirname, 'src/custom/TableContainer.tsx'),
+      '@mui/material/useMediaQuery': resolve(__dirname, 'src/custom/useMediaQuery.ts'),
       '@mui/material/styles': resolve(__dirname, 'src/utils/color.utils.ts'),
       '@mui/icons-material': resolve(__dirname, 'src/custom/icons'),
     },


### PR DESCRIPTION
## Summary
- revert direct Chakra refactors
- alias `@mui/material/useMediaQuery` and `@mui/material/styles`
- implement Chakra-based `useMediaQuery` wrapper
- fix color utils exports and update theme helper

## Testing
- `pnpm --filter material-react-table exec vitest run`